### PR TITLE
diagnostics for queries & parse-tree editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                 "command": "vscode-treesitter-notebook.new",
                 "title": "Tree-Sitter Notebook",
                 "category": "Tree-Sitter Query"
+            },
+            {
+                "command": "vscode-treesitter-parse-tree-editor.createToSide",
+                "title": "Open Parse Tree View to Side",
+                "category": "Tree-Sitter"
             }
         ],
         "menus": {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -36,19 +36,9 @@ function isQueryCell(cell: vscode.NotebookCell) {
 	return cell.document.languageId === NotebookSerializer.queryLanguageId;
 }
 
-declare var navigator: object | undefined;
 
 export function createNotebookController(extensionUri: vscode.Uri) {
 	return vscode.notebooks.createNotebookController('tree-sitter-query', 'tree-sitter-query', 'Tree Sitter Playground', async (cells, notebook, controller) => {
-		// We only need to provide these options when running in the web worker
-		const options: object | undefined = typeof navigator === 'undefined'
-			? undefined
-			: {
-				locateFile() {
-					return vscode.Uri.joinPath(extensionUri, 'dist', 'tree-sitter.wasm').toString(true);
-				}
-			};
-		await Parser.init(options);
 		const parser = new Parser();
 		let codeDocument: vscode.TextDocument | undefined;
 		for (const cell of cells) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -83,7 +83,7 @@ export function createNotebookController(extensionUri: vscode.Uri) {
 					}
 
 				} else {
-					data = printParseTree(parseTree.rootNode).join('\n');
+					data = printParseTree(parseTree.rootNode, { printOnlyNamed: true }).join('\n');
 				}
 
 				await updateOutput(execution, data);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,11 +2,29 @@ import * as vscode from 'vscode';
 import { NotebookSerializer } from './serializer';
 import { createNotebookController } from './controller';
 import { WASMLanguage } from './treeSitter';
+import Parser from 'web-tree-sitter';
+import { QueryDiagnosticsProvider } from './queryDiagnosticsProvider';
 
-export function activate(context: vscode.ExtensionContext) {
+declare var navigator: object | undefined;
+
+export async function activate(context: vscode.ExtensionContext) {
 	const serializer = new NotebookSerializer();
 	const controller = createNotebookController(context.extensionUri);
 	controller.supportedLanguages = [NotebookSerializer.queryLanguageId, ...Object.values(WASMLanguage)];
+
+	// We only need to provide these options when running in the web worker
+	const options: object | undefined = typeof navigator === 'undefined'
+		? undefined
+		: {
+			locateFile() {
+				return vscode.Uri.joinPath(context.extensionUri, 'dist', 'tree-sitter.wasm').toString(true);
+			}
+		};
+	await Parser.init(options);
+
+	const queryDiagnosticsProvider = new QueryDiagnosticsProvider(context.extensionUri);
+	await queryDiagnosticsProvider.init();
+
 	context.subscriptions.push(
 		vscode.workspace.registerNotebookSerializer('tree-sitter-query', serializer),
 		vscode.commands.registerCommand('vscode-treesitter-notebook.new', async () => {
@@ -14,8 +32,9 @@ export function activate(context: vscode.ExtensionContext) {
 			const notebookDocument = await vscode.workspace.openNotebookDocument("tree-sitter-query", data);
 			await vscode.commands.executeCommand("vscode.openWith", notebookDocument.uri, "tree-sitter-query");
 		}),
+		queryDiagnosticsProvider,
 	);
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { createNotebookController } from './controller';
 import { WASMLanguage } from './treeSitter';
 import Parser from 'web-tree-sitter';
 import { QueryDiagnosticsProvider } from './queryDiagnosticsProvider';
+import { createParseTreeEditorCommand } from './parseTreeEditor';
 
 declare var navigator: object | undefined;
 
@@ -33,6 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			await vscode.commands.executeCommand("vscode.openWith", notebookDocument.uri, "tree-sitter-query");
 		}),
 		queryDiagnosticsProvider,
+		vscode.commands.registerCommand('vscode-treesitter-parse-tree-editor.createToSide', () => createParseTreeEditorCommand(context)),
 	);
 }
 

--- a/src/parseTreeEditor.ts
+++ b/src/parseTreeEditor.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode';
+import Parser from 'web-tree-sitter';
+import { WASMLanguage, loadLanguage } from './treeSitter';
+import { printParseTree } from './parseTreePrinter';
+
+const PARSE_TREE_EDITOR_VIEW_TYPE = 'vscode-treesitter-parse-tree-editor';
+
+type OriginalFileRange = {
+	start: Parser.Point;
+	end: Parser.Point;
+};
+
+export class ParseTreeEditor {
+
+	constructor(
+		private readonly context: vscode.ExtensionContext,
+		document: vscode.TextDocument,
+		webviewPanel: vscode.WebviewPanel,
+	) {
+		// Listen for changes in the document
+		const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(async e => {
+			if (e.document.uri.toString() === document.uri.toString()) {
+				this.updateWebview(document, webviewPanel);
+			}
+		});
+
+		// Clean up the event listener when the webview panel is disposed
+		webviewPanel.onDidDispose(() => {
+			changeDocumentSubscription.dispose();
+		});
+
+		// Update the webview content 
+		this.updateWebview(document, webviewPanel);
+	}
+
+	private async updateWebview(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel) {
+
+		const language = await loadLanguage(this.context.extensionUri, document.languageId as WASMLanguage);
+		const parser = new Parser();
+		parser.setLanguage(language);
+
+		const tree = parser.parse(document.getText());
+
+		// Set the webview's HTML to the parse tree
+		webviewPanel.webview.html = `
+			<!DOCTYPE html>
+			<html>
+				<head>
+				</head>
+				<body>
+					<h1> Parse Tree </h1>
+					${printParseTree(tree.rootNode, { printOnlyNamed: false }, ParseTreeEditor.renderNode).join('\n')}
+					<script>
+					
+						const api = acquireVsCodeApi();
+					
+						function handleMouseOver(event) {
+							const hoveredElement = event.target;
+							hoveredElement.style.textDecoration = 'underline';
+							
+							console.log('hoveredElement.dataset.range: ', hoveredElement.dataset.range)
+
+							// Send a message to the extension with the information about the hovered element
+							api.postMessage({
+								eventKind: 'hover',
+								originalFileRange: hoveredElement.dataset.range, // stringified JSON - see OriginalFileRange
+							});
+						}
+					</script>
+				</body>
+			</html>
+		`;
+
+		webviewPanel.webview.onDidReceiveMessage(message => {
+			console.log(message);
+			const { originalFileRange } = message;
+			const { start, end } = JSON.parse(originalFileRange) as OriginalFileRange;
+
+			const startPos = new vscode.Position(start.row, start.column);
+			const endPos = new vscode.Position(end.row, end.column);
+
+			// set selection of document to the range of the hovered element
+			const editorForThisDoc = vscode.window.visibleTextEditors.find(editor => editor.document.uri.toString() === document.uri.toString());
+			if (editorForThisDoc) {
+				editorForThisDoc.selection = new vscode.Selection(startPos, endPos);
+				editorForThisDoc.revealRange(new vscode.Range(startPos, endPos), vscode.TextEditorRevealType.Default);
+			}
+		});
+	}
+
+	private static renderNode(node: Parser.SyntaxNode, depth: number, fieldName: string | undefined) {
+		const fieldNameStr = fieldName ? `${fieldName}: ` : '';
+		const range: OriginalFileRange = {
+			start: node.startPosition,
+			end: node.endPosition,
+		};
+		const stringifiedRange = JSON.stringify(range).replace(/"/g, '&quot;'); // escape double quotes for HTML
+		return `
+			<a 
+				style="margin-left:${depth * 30}px; font-size: 16px; cursor: pointer;" 
+				onmouseover="handleMouseOver(event)"
+				onmouseout="event.target.style.textDecoration = ''"
+				data-range="${stringifiedRange}"
+			>
+				${fieldNameStr}${node.type}
+			</a>
+			[${node.startPosition.row}, ${node.startPosition.column}] - [${node.endPosition.row}, ${node.endPosition.column}]
+			<br/>`;
+	}
+}
+
+export async function createParseTreeEditorCommand(context: vscode.ExtensionContext) {
+	const activeDocument = vscode.window.activeTextEditor?.document;
+	if (!activeDocument || !Object.values(WASMLanguage).includes(activeDocument.languageId as WASMLanguage)) {
+		return;
+	}
+
+	const panel = vscode.window.createWebviewPanel(
+		PARSE_TREE_EDITOR_VIEW_TYPE,
+		`Parse Tree for ${activeDocument.fileName}`,
+		vscode.ViewColumn.Two,
+		{
+			enableScripts: true,
+		}
+	);
+
+	// Create and show panel
+	new ParseTreeEditor(context, activeDocument, panel);
+}

--- a/src/parseTreePrinter.ts
+++ b/src/parseTreePrinter.ts
@@ -39,7 +39,7 @@ export function printParseTree(node: Parser.SyntaxNode, options: PrintingOptions
 }
 
 function printNode(node: Parser.SyntaxNode, depth: number, fieldName: string | undefined) {
-	const indent = ' '.repeat(depth * 2);
+	const indent = ' '.repeat(depth * 4);
 	const fieldNameStr = fieldName ? `${fieldName}: ` : '';
 	return `${indent}${fieldNameStr}${node.type} [${node.startPosition.row}, ${node.startPosition.column}] - [${node.endPosition.row}, ${node.endPosition.column}]`;
 }	

--- a/src/parseTreePrinter.ts
+++ b/src/parseTreePrinter.ts
@@ -1,6 +1,10 @@
 import Parser from "web-tree-sitter";
 
-export function printParseTree(node: Parser.SyntaxNode): string[] {
+type PrintingOptions = {
+	printOnlyNamed: boolean;
+};
+
+export function printParseTree(node: Parser.SyntaxNode, options: PrintingOptions): string[] {
 	const printedNodes: string[] = [];
 
 	const cursor = node.walk();
@@ -11,7 +15,7 @@ export function printParseTree(node: Parser.SyntaxNode): string[] {
 	while (depth >= 0) {
 		const isNodeUnexplored = lastSeenDepth <= depth;
 
-		if (isNodeUnexplored && cursor.currentNode().isNamed()) {
+		if (isNodeUnexplored && (!options.printOnlyNamed || cursor.currentNode().isNamed())) {
 			const currentNode = cursor.currentNode();
 			printedNodes.push(printNode(currentNode, depth, cursor.currentFieldName()));
 		}

--- a/src/parseTreePrinter.ts
+++ b/src/parseTreePrinter.ts
@@ -1,0 +1,41 @@
+import Parser from "web-tree-sitter";
+
+export function printParseTree(node: Parser.SyntaxNode): string[] {
+	const printedNodes: string[] = [];
+
+	const cursor = node.walk();
+	let depth = 0;
+	let lastSeenDepth = 0;
+
+	// depth-first pre-order tree traversal
+	while (depth >= 0) {
+		const isNodeUnexplored = lastSeenDepth <= depth;
+
+		if (isNodeUnexplored && cursor.currentNode().isNamed()) {
+			const currentNode = cursor.currentNode();
+			printedNodes.push(printNode(currentNode, depth, cursor.currentFieldName()));
+		}
+
+		lastSeenDepth = depth;
+
+		if (isNodeUnexplored && cursor.gotoFirstChild()) {
+			++depth;
+			continue;
+		}
+
+		if (cursor.gotoNextSibling()) {
+			continue;
+		}
+
+		cursor.gotoParent();
+		--depth;
+	}
+
+	return printedNodes;
+}
+
+function printNode(node: Parser.SyntaxNode, depth: number, fieldName: string | undefined) {
+	const indent = ' '.repeat(depth * 2);
+	const fieldNameStr = fieldName ? `${fieldName}: ` : '';
+	return `${indent}${fieldNameStr}${node.type} [${node.startPosition.row}, ${node.startPosition.column}] - [${node.endPosition.row}, ${node.endPosition.column}]`;
+}	

--- a/src/queryDiagnosticsProvider.ts
+++ b/src/queryDiagnosticsProvider.ts
@@ -1,0 +1,227 @@
+import * as vscode from 'vscode';
+import Parser from 'web-tree-sitter';
+import { WASMLanguage, loadLanguage } from './treeSitter';
+import { Lazy } from './utils';
+
+export class QueryDiagnosticsProvider {
+
+	private typescriptLanguage: Parser.Language | undefined;
+	private treeSitterQueryTemplateStringQuery: Parser.Query | undefined;
+
+	private queryDiagnosticsCollection: vscode.DiagnosticCollection;
+	private disposables: vscode.Disposable[] = [];
+
+	constructor(
+		private readonly extensionUri: vscode.Uri
+	) {
+
+		this.queryDiagnosticsCollection = vscode.languages.createDiagnosticCollection("tree-sitter-query");
+
+		this.disposables.push(
+
+			vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+				if (!editor) {
+					this.queryDiagnosticsCollection.clear();
+					return;
+				}
+
+				await this.updateDiagnostics(editor.document);
+			}),
+
+			vscode.workspace.onDidChangeTextDocument(e => this.updateDiagnostics(e.document)),
+
+			vscode.workspace.onDidCloseTextDocument(doc => {
+				if (this.queryDiagnosticsCollection.has(doc.uri)) {
+					this.queryDiagnosticsCollection.delete(doc.uri);
+				};
+			}),
+		);
+	}
+
+	async init() {
+		this.typescriptLanguage = await loadLanguage(this.extensionUri, WASMLanguage.TypeScript);
+		this.treeSitterQueryTemplateStringQuery = this.typescriptLanguage.query(`
+		(call_expression
+			function: (member_expression
+							object: (identifier) @identifier
+							(#eq? @identifier "treeSitterQuery")
+							property: (property_identifier) @target_language
+							(#any-of? @target_language 
+								${Object.values(WASMLanguage).map(lang => `"${lang}"`).join(' ')}
+							)
+						)
+			arguments: (template_string) @query_src_with_quotes
+		) @call_expression
+		`);
+
+		this.disposables.push(new vscode.Disposable(() => this.treeSitterQueryTemplateStringQuery?.delete()));
+
+		if (vscode.window.activeTextEditor) {
+			this.updateDiagnostics(vscode.window.activeTextEditor.document);
+		}
+	}
+
+	async updateDiagnostics(document: vscode.TextDocument) {
+
+		switch (document.languageId) {
+			case 'typescript':
+				return this.updateDiagnosticsInTypescriptSourceFile(document);
+			case 'scm':
+				return this.updateDiagnosticsInScmFile(document);
+			default:
+				return;
+		}
+	}
+
+	private async updateDiagnosticsInTypescriptSourceFile(document: vscode.TextDocument) {
+
+		const parser = new Parser();
+		parser.setLanguage(this.typescriptLanguage!);
+		try {
+			const parseTree = parser.parse(document.getText());
+			const matches = this.treeSitterQueryTemplateStringQuery!.matches(parseTree.rootNode);
+			if (matches.length === 0) {
+				return;
+			}
+			const treeSitterQueries = InSourceTreeSitterQuery.fromQueryMatches(matches);
+			const errors = await Promise.all(treeSitterQueries.map(query => query.getError(this.extensionUri)));
+			const diagnostics: vscode.Diagnostic[] = [];
+
+			for (let i = 0; i < errors.length; i++) {
+				const error = errors[i];
+
+				if (/* is tree-sitter query parsing error */
+					error && typeof error === 'object' &&
+					'index' in error && typeof error.index === 'number' &&
+					'message' in error && typeof error.message === 'string'
+				) {
+					const diagnosticStartPos = document.positionAt(treeSitterQueries[i].queryWithQuotes.startIndex + 1 + error.index);
+					const diagnosticEndPos = document.lineAt(diagnosticStartPos.line).range.end;
+					const diagnosticRange = new vscode.Range(diagnosticStartPos, diagnosticEndPos);
+					const errorMessage = error.message.replace(/ at offset (\d+)/g, '').replace(/\.\.\.$/g, '');
+					const diagnostic = new vscode.Diagnostic(diagnosticRange, errorMessage, vscode.DiagnosticSeverity.Error);
+					diagnostics.push(diagnostic);
+				}
+			}
+
+			this.queryDiagnosticsCollection.set(document.uri, diagnostics);
+		} catch (e) {
+			console.error(JSON.stringify(e, null, '\t'));
+		} finally {
+			parser.delete();
+		}
+	}
+
+	private async updateDiagnosticsInScmFile(document: vscode.TextDocument) {
+
+		const topMostLine = document.lineAt(0).text.trim();
+		if (!topMostLine.startsWith(';;')) {
+			return;
+		}
+		const targetLang = topMostLine.slice(2).trim().toLocaleLowerCase();
+		if (!Object.values(WASMLanguage).includes(<WASMLanguage>targetLang)) {
+			return;
+		}
+
+		const language = await loadLanguage(this.extensionUri, <WASMLanguage>targetLang);
+
+		let error: Error | undefined;
+		try {
+			language.query(document.getText());
+		} catch (e) {
+			if (e instanceof Error) {
+				error = e;
+			} else {
+				error = new Error(JSON.stringify(e, null, '\t'));
+			}
+		}
+
+		const diagnostics: vscode.Diagnostic[] = [];
+
+		if (/* is tree-sitter query parsing error */
+			error && typeof error === 'object'
+		) {
+			let diagnosticStartPos: vscode.Position;
+			let diagnosticEndPos: vscode.Position;
+			if ('index' in error && typeof error.index === 'number') {
+				diagnosticStartPos = document.positionAt(error.index);
+				diagnosticEndPos = document.lineAt(diagnosticStartPos.line).range.end;
+			} else {
+				const offsetInErrorMessage = error.message.match(/ at offset (\d+)/)?.[1];
+				if (offsetInErrorMessage) {
+					diagnosticStartPos = document.positionAt(Number(offsetInErrorMessage));
+					diagnosticEndPos = document.lineAt(diagnosticStartPos.line).range.end;
+				} else { // whole document
+					diagnosticStartPos = new vscode.Position(0, 0);
+					diagnosticEndPos = document.lineAt(document.lineCount - 1 /* because 0-indexed */).range.end;
+				}
+			}
+			const diagnosticRange = new vscode.Range(diagnosticStartPos, diagnosticEndPos);
+
+			let errorMessage: string;
+			if ('message' in error && typeof error.message === 'string') {
+				errorMessage = error.message.replace(/ at offset (\d+)/g, '').replace(/\.\.\.$/g, '');
+			} else {
+				errorMessage = JSON.stringify(error, null, '\t');
+			}
+
+			const diagnostic = new vscode.Diagnostic(diagnosticRange, errorMessage, vscode.DiagnosticSeverity.Error);
+
+			diagnostics.push(diagnostic);
+		}
+
+		this.queryDiagnosticsCollection.set(document.uri, diagnostics);
+
+	}
+
+	dispose() {
+		this.disposables.forEach(d => d.dispose());
+	}
+}
+
+class InSourceTreeSitterQuery {
+	readonly _querySrc: Lazy<string>;
+
+	constructor(
+		readonly targetLanguage: Parser.SyntaxNode,
+		readonly queryWithQuotes: Parser.SyntaxNode,
+	) {
+		this._querySrc = new Lazy(() => this.queryWithQuotes.text.slice(1, -1));
+	}
+
+	get querySrc() {
+		return this._querySrc.value;
+	}
+
+	async getError(extensionUri: vscode.Uri) {
+		if (!Object.values(WASMLanguage).includes(this.targetLanguage.text as WASMLanguage)) {
+			return undefined;
+		}
+
+		try {
+			const language = await loadLanguage(extensionUri, this.targetLanguage.text as WASMLanguage);
+			language.query(this.querySrc);
+			return undefined;
+		} catch (e) {
+			return e;
+		}
+	}
+
+	static fromQueryMatches(matches: Parser.QueryMatch[]): InSourceTreeSitterQuery[] {
+		const captures = matches.flatMap(({ captures }) => captures)
+			.sort((a, b) => a.node.startIndex - b.node.startIndex || b.node.endIndex - a.node.endIndex);
+
+		const treeSitterQueries: InSourceTreeSitterQuery[] = [];
+		for (let i = 0; i < captures.length;) {
+			const capture = captures[i];
+			if (capture.name === 'call_expression' && captures[i + 2].name === 'target_language' && captures[i + 3].name === 'query_src_with_quotes') {
+				treeSitterQueries.push(new InSourceTreeSitterQuery(captures[i + 2].node, captures[i + 3].node));
+				i += 4;
+			} else {
+				i++;
+			}
+		}
+
+		return treeSitterQueries;
+	}
+}

--- a/src/treeTraversal.ts
+++ b/src/treeTraversal.ts
@@ -1,0 +1,38 @@
+import Parser, { TreeCursor } from "web-tree-sitter";
+
+type NodeProcessor = {
+	/**
+	 * @remark can access current node using `cursor.currentNode()`; don't modify the cursor
+	 */
+	(cursor: TreeCursor, depth: number): void;
+};
+
+export function traverseDFPreOrder(node: Parser.SyntaxNode, fn: NodeProcessor) {
+
+	const cursor = node.walk();
+	let depth = 0;
+	let lastSeenDepth = 0;
+
+	// depth-first pre-order tree traversal
+	while (depth >= 0) {
+		const isNodeUnexplored = lastSeenDepth <= depth;
+
+		if (isNodeUnexplored) {
+			fn(cursor, depth);
+		}
+
+		lastSeenDepth = depth;
+
+		if (isNodeUnexplored && cursor.gotoFirstChild()) {
+			++depth;
+			continue;
+		}
+
+		if (cursor.gotoNextSibling()) {
+			continue;
+		}
+
+		cursor.gotoParent();
+		--depth;
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+export class Lazy<T extends NonNullable<any>> {
+
+    private _value: T | undefined;
+
+    constructor(private readonly init: () => T) {
+    }
+
+    get value(): T {
+        if (this._value === undefined) {
+            this._value = this.init();
+        }
+        return this._value;
+    }
+}


### PR DESCRIPTION
implements diagnostics for 

- typescript files -- the template string within `treeSitterQuery.<language>` template string formatting function is checked for

- query files .scm with the top line being a comment containing language, e.g., `;; typescript` (works for notebook cells as well but still requires top comment)

----

implements a parse-tree viewer using a webview (hovering over parse-tree node highlights corresponding original file, but doesn't work the other way around) 


----

I hope to address limitations above in further PRs when I have more time